### PR TITLE
Add provider and DNS form parsing with lint workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,16 @@ jobs:
           - { arch: "mediatek", sub: "filogic" }
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-      - name: Prepare
+    - name: Lint Lua sources
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y lua5.1
+        find luasrc -name '*.lua' -print0 | xargs -0 -n1 luac -p
+
+    - name: Prepare
         run: |
           VER="${{ github.event.inputs.owrt_version || '24.10.0' }}"
           echo "VER=$VER" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - DNS `nameserver` 仅 IPv4，其他 DNS 选项原样保留；
 - 日志查看（`/etc/nikki/nodemanager.log` 或 `logread`）；
 - i18n：中文、英文；
-- GitHub Action 云编译：OpenWrt 24.10.x，x86_64 与 mediatek/filogic。
+- GitHub Action 云编译：OpenWrt 24.10.x，mediatek/filogic。
 
 ## 安装
 ```sh

--- a/luasrc/nodemanager/util.lua
+++ b/luasrc/nodemanager/util.lua
@@ -475,6 +475,59 @@ function M.parse_proxy_form(form)
   return true, list
 end
 
+function M.parse_provider_form(form)
+  local names = form["name[]"] or form.name
+  local urls  = form["url[]"]  or form.url
+
+  if type(names) == "string" then
+    names = { names }
+    urls  = { urls }
+  end
+
+  local list = {}
+  local total = #(names or {})
+  for i = 1, total do
+    local n = trim((names and names[i]) or "")
+    local u = trim((urls  and urls[i])  or "")
+    local all_blank = (n == "" and u == "")
+    if not all_blank then
+      if n == "" or u == "" then
+        return false, nil, i18n.translate("Fields cannot be empty")
+      end
+      if not is_http_url(u) then
+        return false, nil, i18n.translatef("Invalid URL at row %d", i)
+      end
+      table.insert(list, { name = n, url = u })
+    end
+  end
+
+  return true, list
+end
+
+function M.parse_dns_form(form)
+  local dns = form["dns[]"] or form.dns
+
+  if type(dns) == "string" then dns = { dns } end
+
+  local list = {}
+  local total = #(dns or {})
+  for i = 1, total do
+    local ip = trim((dns and dns[i]) or "")
+    if ip ~= "" then
+      if not is_ipv4(ip) then
+        return false, nil, i18n.translatef("Invalid DNS at row %d", i)
+      end
+      table.insert(list, ip)
+    end
+  end
+
+  if #list == 0 then
+    return false, nil, i18n.translate("DNS cannot be empty")
+  end
+
+  return true, list
+end
+
 -- ===== Save: proxies & rules =====
 function M.save_proxies_and_rules(list)
   local lines = read_lines()

--- a/root/usr/share/rpcd/acl.d/luci-app-nodemanager.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-nodemanager.json
@@ -1,6 +1,6 @@
 {
   "luci-app-nodemanager": {
-    "description": "Grant LuCI NodeManager permissions",
+    "description": "Grant LuCI Node Manager permissions",
     "read": {
       "file": {
         "/etc/nikki/profiles/config.yaml": [ "read" ]


### PR DESCRIPTION
## Summary
- add missing provider and DNS form parsers
- correct ACL description and README target list
- lint Lua sources in CI

## Testing
- `luac -p luasrc/nodemanager/util.lua` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6bf773a883309d2cae9129755bec